### PR TITLE
Profile verification via e-mail

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "rebuk/pro_state_demo",
+    "name": "armands62/pro_state",
     "type": "project",
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "Rebuk\\ProStateDemo\\": "src/"
+            "armands62\\ProState\\": "src/"
         }
     },
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
-    "name": "armands62/pro_state",
+    "name": "rebuk/pro_state_demo",
     "type": "project",
     "license": "MIT",
     "autoload": {
         "psr-4": {
-            "armands62\\ProState\\": "src/"
+            "Rebuk\\ProStateDemo\\": "src/"
         }
     },
     "minimum-stability": "dev",

--- a/pro_state.sql
+++ b/pro_state.sql
@@ -1,0 +1,143 @@
+-- phpMyAdmin SQL Dump
+-- version 5.1.1
+-- https://www.phpmyadmin.net/
+--
+-- Host: 127.0.0.1
+-- Generation Time: Dec 27, 2022 at 10:23 PM
+-- Server version: 10.4.21-MariaDB
+-- PHP Version: 8.0.11
+
+SET SQL_MODE = "NO_AUTO_VALUE_ON_ZERO";
+START TRANSACTION;
+SET time_zone = "+00:00";
+
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+
+--
+-- Database: `pro_state`
+--
+CREATE DATABASE IF NOT EXISTS `pro_state` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+USE `pro_state`;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `account`
+--
+
+CREATE TABLE `account` (
+  `id` int(11) NOT NULL,
+  `number` char(21) NOT NULL,
+  `name` varchar(60) NOT NULL,
+  `user_id` int(11) NOT NULL,
+  `available` double NOT NULL,
+  `reserved` double NOT NULL,
+  `daily_limit` double NOT NULL DEFAULT 35,
+  `monthly_limit` double NOT NULL DEFAULT 500
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `transaction_history`
+--
+
+CREATE TABLE `transaction_history` (
+  `id` int(11) NOT NULL,
+  `account_from` int(11) NOT NULL,
+  `account_to` int(11) NOT NULL,
+  `amount` double NOT NULL,
+  `description` varchar(255) NOT NULL,
+  `date` date NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `user`
+--
+
+CREATE TABLE `user` (
+  `id` int(11) NOT NULL,
+  `name` varchar(60) NOT NULL,
+  `surname` varchar(60) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `password` varchar(256) NOT NULL,
+  `social_number` varchar(12) NOT NULL,
+  `birth_date` date NOT NULL,
+  `gender` varchar(6) NOT NULL,
+  `auth` int(11) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+--
+-- Indexes for dumped tables
+--
+
+--
+-- Indexes for table `account`
+--
+ALTER TABLE `account`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `user_id` (`user_id`);
+
+--
+-- Indexes for table `transaction_history`
+--
+ALTER TABLE `transaction_history`
+  ADD PRIMARY KEY (`id`),
+  ADD KEY `account_from` (`account_from`,`account_to`),
+  ADD KEY `account_to` (`account_to`);
+
+--
+-- Indexes for table `user`
+--
+ALTER TABLE `user`
+  ADD PRIMARY KEY (`id`);
+
+--
+-- AUTO_INCREMENT for dumped tables
+--
+
+--
+-- AUTO_INCREMENT for table `account`
+--
+ALTER TABLE `account`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `transaction_history`
+--
+ALTER TABLE `transaction_history`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- AUTO_INCREMENT for table `user`
+--
+ALTER TABLE `user`
+  MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+--
+-- Constraints for dumped tables
+--
+
+--
+-- Constraints for table `account`
+--
+ALTER TABLE `account`
+  ADD CONSTRAINT `account_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`);
+
+--
+-- Constraints for table `transaction_history`
+--
+ALTER TABLE `transaction_history`
+  ADD CONSTRAINT `transaction_history_ibfk_1` FOREIGN KEY (`account_from`) REFERENCES `account` (`id`),
+  ADD CONSTRAINT `transaction_history_ibfk_2` FOREIGN KEY (`account_to`) REFERENCES `account` (`id`);
+COMMIT;
+
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;

--- a/src/authorize.php
+++ b/src/authorize.php
@@ -1,0 +1,35 @@
+<!doctype html>
+    <html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport"
+              content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
+        <meta http-equiv="X-UA-Compatible" content="ie=edge">
+        <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+        <link href="src/css/main.css" type="text/css" rel="stylesheet">
+        <title>Pro State Bank</title>
+    </head>
+    <body>
+    <main class="login-main">
+        <div class="login-container">
+            <h2>Apstiprināt e-pastu</h2>
+            <?php
+            if(!empty($_SESSION["login_err_msg"])){
+                echo "<p class='login-error'>{$_SESSION["login_err_msg"]}</p>";
+                unset($_SESSION["login_err_msg"]);
+            }
+            ?>
+            <form action="/check_auth" method="POST" class="login-page-authenticate">
+                <label for="auth">Apstiprināšanas kods</label>
+                <input type="text" name="auth" placeholder="000000" id="login-email" required>
+                <p><a href="/" class="to-homepage">Atgriezties galvenajā lapā</a></p>
+                <p><a href="/send_auth">Sūtīt e-pastu atkārtoti</a></p>
+                <input type="submit" value="Apstiprināt" id="submit">
+            </form>
+        </div>
+    </main>
+    </body>
+    </html>
+
+<?php
+include_once("blocks/footer.phtml");

--- a/src/backend/authenticate.php
+++ b/src/backend/authenticate.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 include_once('dbconn.php');
+include_once('sendauth.php');
 $dbconn = new dbconn();
 $con = $dbconn->db();
 
@@ -34,6 +35,7 @@ if($stmt = $con->prepare('SELECT `id`, `password` FROM `user` WHERE `email` = ?;
             $_SESSION['logged'] = true;
             $_SESSION['email'] = $_POST['email'];
             $_SESSION['id'] = $id;
+            $_SESSION['auth'] = Authorization::get_auth($id);
             $_SESSION['last_activity'] = time();
             header('Location: /');
         }

--- a/src/backend/check_auth.php
+++ b/src/backend/check_auth.php
@@ -1,0 +1,12 @@
+<?php
+include_once('sendauth.php');
+if ($_POST['auth'] < 100000 || $_POST['auth'] > 999999) {
+    return;
+}
+if(Authorization::check_auth($_SESSION['id'], $_POST['auth'])) {
+    $_SESSION['auth'] = 0;
+    header('Location: /profile');
+    exit();
+} else {
+    header('Location: /authorize');
+}

--- a/src/backend/logout.php
+++ b/src/backend/logout.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 session_destroy();
 header("Location: /");
 exit();

--- a/src/backend/mail.php
+++ b/src/backend/mail.php
@@ -3,9 +3,9 @@
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\SMTP;
-require ("./vendor/phpmailer/phpmailer/src/Exception.php");
-require ("./vendor/phpmailer/phpmailer/src/PHPMailer.php");
-require ("./vendor/phpmailer/phpmailer/src/SMTP.php");
+require ("../vendor/phpmailer/phpmailer/src/Exception.php");
+require ("../vendor/phpmailer/phpmailer/src/PHPMailer.php");
+require ("../vendor/phpmailer/phpmailer/src/SMTP.php");
 
 class Mailer {
     private $mail;

--- a/src/backend/send_auth.php
+++ b/src/backend/send_auth.php
@@ -1,0 +1,4 @@
+<?php
+include_once('sendauth.php');
+Authorization::send_auth($_SESSION['id']);
+header('Location: /authorize');

--- a/src/backend/sendauth.php
+++ b/src/backend/sendauth.php
@@ -1,0 +1,53 @@
+<?php
+include_once('mail.php');
+include_once('dbconn.php');
+include_once('userinfo.php');
+
+class Authorization {
+    public static function send_auth($id) {
+        $user_info = get_profile($id);
+
+        $mail = new Mailer();
+        $mail->set_recipient($user_info['email'], $user_info['name'] . ' ' . $user_info['surname']);
+        $mail->set_subject('Reģistrācijas apstiprināšanas kods');
+        $mail->set_content('Zemāk ir norādīts reģistrācijas apstiprinājuma kods. Ievadiet kodu Pro State Bank reģistrācijas apstiprinājuma lapā.</br><span style="color: red;"> ' . self::get_auth($id) . '</span>');
+
+        try {
+            $mail->send();
+        } catch (\PHPMailer\PHPMailer\Exception $e) {
+            echo $e;
+        }
+    }
+    public static function check_auth($id, $auth)
+    {
+        $dbconn = new dbconn();
+        $con = $dbconn->db();
+        $auth_db = self::get_auth($id);
+        if ($auth_db == 0) {
+            return;
+        }
+        if($auth == $auth_db) {
+            if ($stmt = $con->prepare('UPDATE `user` SET `auth` = 0 WHERE `id` = ?;')) {
+                $stmt->bind_param('i', $id);
+                $stmt->execute();
+                $stmt->store_result();
+                return true;
+            }
+        }
+        return false;
+    }
+    public static function get_auth($id)
+    {
+        $dbconn = new dbconn();
+        $con = $dbconn->db();
+        if ($stmt = $con->prepare('SELECT `auth` FROM `user` WHERE `id` = ?;')) {
+            $stmt->bind_param('i', $id);
+            $stmt->execute();
+            $stmt->store_result();
+            $auth_db = '';
+            $stmt->bind_result($auth_db);
+            $stmt->fetch();
+            return $auth_db;
+        }
+    }
+}

--- a/src/backend/transfer.php
+++ b/src/backend/transfer.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 if(empty($_SESSION['logged'])) {
     header('Location: /login');
     exit();

--- a/src/backend/update_account.php
+++ b/src/backend/update_account.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 include_once('dbconn.php');
 $dbconn = new dbconn();
 $con = $dbconn->db();

--- a/src/backend/update_profile.php
+++ b/src/backend/update_profile.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 include_once('dbconn.php');
 $dbconn = new dbconn();
 $con = $dbconn->db();

--- a/src/index.php
+++ b/src/index.php
@@ -1,7 +1,7 @@
 <?php
 session_start();
 if (isset($_SESSION['last_activity'])) {
-    if (time() - $_SESSION['last_activity'] > 60) {
+    if (time() - $_SESSION['last_activity'] > 1200) {
         header('Location: /logout');
     } else {
         $_SESSION['last_activity'] = time();
@@ -18,12 +18,39 @@ if ($request_method == 'POST') {
     // Routing for all pages where the user must be logged in
     if ($requested_url == '/profile' || $requested_url == '/accounts' || $requested_url == '/money_transfer'
         || $requested_url == '/view_account' || $requested_url == '/history' || $requested_url == '/logout'
-        || $requested_url == '/edit_profile' || $requested_url == '/add_account' || $requested_url == '/edit_account') {
-        if (is_logged()) {
+        || $requested_url == '/edit_profile' || $requested_url == '/add_account' || $requested_url == '/edit_account'
+        || $requested_url == '/authorize' || $requested_url == '/send_auth') {
+        if (!empty($_SESSION["logged"])) {
+
+            // Links with larger priorities
+            if ($requested_url == '/profile') {
+                include 'profile.php';
+                exit();
+            }
+            if($requested_url == '/logout') {
+                include 'backend/logout.php';
+                exit();
+            }
+            if($requested_url == '/edit_profile') {
+                include 'edit_profile.php';
+                exit();
+            }
+            if($requested_url == '/send_auth') {
+                include 'backend/send_auth.php';
+                exit();
+            }
+            if($requested_url == '/authorize') {
+                include 'authorize.php';
+                exit();
+            }
+            if ($_SESSION['auth'] != 0) {
+                $_SESSION['login_err_msg'] = 'Lai piekļūtu šai lapai, ir nepieciešams aktivizēt kontu! Pārbaudiet savu e-pastu!';
+                include 'authorize.php';
+                exit();
+            }
+
+            // Regular logged in links
             switch ($requested_url) {
-                case '/profile':
-                    include 'profile.php';
-                    break;
                 case '/accounts':
                     include 'accounts.php';
                     break;
@@ -35,12 +62,6 @@ if ($request_method == 'POST') {
                     break;
                 case '/history':
                     include 'history.php';
-                    break;
-                case '/logout':
-                    include 'backend/logout.php';
-                    break;
-                case '/edit_profile':
-                    include 'edit_profile.php';
                     break;
                 case '/add_account':
                     include 'add_account.php';
@@ -54,6 +75,7 @@ if ($request_method == 'POST') {
             exit();
         } else {
             header('Location: /login');
+            exit();
         }
     }
     // Common page routes
@@ -73,6 +95,7 @@ if ($request_method == 'POST') {
         default:
             include '404.php';
     }
+    exit();
 }
 
 // Routing with POST request
@@ -106,6 +129,9 @@ function process_post_request($requested_url) {
         case '/transfer':
             include 'backend/transfer.php';
             break;
+        case '/check_auth':
+            include 'backend/check_auth.php';
+            break;
         default:
             echo('POST');
             include '404.php';
@@ -113,10 +139,3 @@ function process_post_request($requested_url) {
     }
 }
 
-function is_logged(): bool
-{
-    if(!empty($_SESSION["logged"])) {
-        return true;
-    }
-    return false;
-}

--- a/src/js/auth_send.js
+++ b/src/js/auth_send.js
@@ -1,0 +1,23 @@
+function resend() {
+    let xhttp = new XMLHttpRequest();
+    let url = "/send";
+    let params;
+
+    if(id === -1) {
+        const ACCOUNT_ID = document.getElementById('account-id');
+        if(ACCOUNT_ID.value == -1) return;
+        params = 'account-id=' + ACCOUNT_ID.value;
+    }
+    else {
+        params = 'account-id=' + id;
+    }
+
+    xhttp.open("POST", url, true);
+    xhttp.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+    xhttp.onreadystatechange = function() {
+        if (this.readyState === 4 && this.status === 200) {
+            document.getElementById("table-container").innerHTML = this.responseText;
+        }
+    };
+    xhttp.send(params);
+}

--- a/src/profile.php
+++ b/src/profile.php
@@ -20,6 +20,12 @@ include_once("backend/userinfo.php");
                     echo '<li>Vārds: ' . $user_info['name'] . '</li>';
                     echo '<li>Uzvārds: ' . $user_info['surname'] . '</li>';
                     echo '<li>E-pasts: ' . $user_info['email'] . '</li>';
+                    if($_SESSION['auth'] == 0) {
+                        echo '<li style="color: green">Profils ir aktivizēts!</li>';
+                    } else {
+                        echo '<li style="color: red">Profils nav aktivizēts!</li>';
+                        echo '<li><a href="/authorize">Aktivizēt kontu</a></li>';
+                    }
                     ?>
                 </ul>
             </div>


### PR DESCRIPTION
Pievienota profila verifikācija ar 6 ciparu verifikācijas kodu, kas tiks sūtīts uz norādīto profila epastu. Tas arī nozīmē, ka iespējams reģistrēt profilus ar citu cilvēku kontiem, un uz norādītajiem kontiem sūtīs Pro State Bank e-pastus. Nevajag.

Pie failiem ir iemests .sql export fails, datu bāzē vajadzēja ievietot verifikācijas numuru katram lietotājam.

E-pasti neies bez local_key.php faila, bet negribu dot sava personīgā profila adresi un paroli, tāpēc būtu labi, ja tos uzstādītu jūs paši. Vai nu atliek izveidot dedicated Pro State Bank gmail epastu un sūtīt no tā. Vienīgā problēma - nepieciešama 2 soļu verifikācija.

P.S. Iespējams būs nepieciešams darīt kaut ko ar composer, jo /vendor mape ir izņemta no repo jeb atrodas .gitignore, lai nepiesārņotu projektu. Brīdinu jau laicīgi.