### PR TITLE
Admin registry/history table hotfix

### DIFF
--- a/src/admin/history.php
+++ b/src/admin/history.php
@@ -25,18 +25,27 @@ include_once("blocks/header.phtml");
                 } else {
                     $i = 0;
                     $page_start = 0;
-                    $page_end = 10;
-                    if(!empty($_GET['page'])) {
-                        $i = $_GET['page'];
-                        $page_start = (($i - 1) * 10) + 1;
-                        $page_end = $page_start + 9;
+                    $page_end = 0;
+                    if(empty($_GET['page'])) {
+                        $_GET['page'] = 1;
                     }
+                    $i = $_GET['page'];
+                    $page_start = ($i - 1) * 11;
+                    $page_end = $page_start + 10;
                     foreach ($transaction_info as $value) {
-                        if($i < $page_start)  {
-                            $i++;
-                            continue;
+                        if($_GET['page'] == 1) {
+                            if($i < $page_start) {
+                                $i++;
+                                continue;
+                            }
                         }
-                        if($i >= $page_end) break;
+                        else if($_GET['page'] > 1) {
+                            if($i <= $page_start) {
+                                $i++;
+                                continue;
+                            }
+                        }
+                        if($i > $page_end) break;
                         $account_from_info = UserInfo::get_account($value[1]);
                         $account_to_info = UserInfo::get_account($value[2]);
                         echo "<tr><th class=\"left\"><a href='/admin_view_account?id=$value[1]'>{$account_from_info['number']}</a> (<a href='/admin_view_profile?id={$account_from_info['user_id']}'>{$account_from_info['user_name']} {$account_from_info['user_surname']}</a>)</th>";

--- a/src/admin/history.php
+++ b/src/admin/history.php
@@ -24,7 +24,7 @@ include_once("blocks/header.phtml");
                     echo '<td>Nav veiktu maksājumu!</td>';
                 } else {
                     $i = 0;
-                    $page_start = 1;
+                    $page_start = 0;
                     $page_end = 10;
                     if(!empty($_GET['page'])) {
                         $i = $_GET['page'];

--- a/src/admin/registry.php
+++ b/src/admin/registry.php
@@ -21,19 +21,29 @@ include_once("blocks/header.phtml");
                     echo '<td>Nav veiktu maksājumu!</td>';
                 } else {
                     $i = 0;
-                    $page_start = 1;
-                    $page_end = 10;
-                    if(!empty($_GET['page'])) {
-                        $i = $_GET['page'];
-                        $page_start = (($i - 1) * 10) + 1;
-                        $page_end = $page_start + 9;
+                    $page_start = 0;
+                    $page_end = 0;
+                    if(empty($_GET['page'])) {
+                        $_GET['page'] = 1;
                     }
+                    $i = $_GET['page'];
+                    $page_start = ($i - 1) * 11;
+                    $page_end = $page_start + 10;
+
                     foreach ($registry_info as $value) {
-                        if($i < $page_start)  {
-                            $i++;
-                            continue;
+                        if($_GET['page'] == 1) {
+                            if($i < $page_start) {
+                                $i++;
+                                continue;
+                            }
                         }
-                        if($i >= $page_end) break;
+                        else if($_GET['page'] > 1) {
+                            if($i <= $page_start) {
+                                $i++;
+                                continue;
+                            }
+                        }
+                        if($i > $page_end) break;
                         $profile_info = UserInfo::get_profile($value[1]);
                         echo "<tr><th class=\"left\"><a href='/admin_view_profile?id=$value[1]'>{$profile_info['name']} {$profile_info['surname']}</a></th>";
                         switch ($value[3]) {

--- a/src/blocks/transaction_table.php
+++ b/src/blocks/transaction_table.php
@@ -20,7 +20,7 @@
     }
     $transaction_info = UserInfo::get_transaction_history($account_info[$_POST['account-id']][0]);
 
-    if($transaction_info == '') {
+    if($transaction_info == []) {
         echo '<td>Nav veiktu maksājumu!</td>';
     } else {
         $i = 0;


### PR DESCRIPTION
- Katrā tabulā tagad tiek rādīta informācija daļās pa 10;
- Tiek izvadīti visi ieraksti, nekas netiek palaists garām;
- Neveidojas ierakstu duplikāti;
- Katrā tabulas lapā tagad ir vienāds skaits ar ierakstiem (tagad katrā 10, iepriekš bij sākumā 10, nākamajos 9 (izņemot pēdējo lapu));
- Izlabota pārbaude uz tukšu string elementu, saņemot tukšu array no datubāzes par transakcijām. Iepriekš netika izvadīts, ka maksājumi nav veikti. Tagad izlabots.